### PR TITLE
fix deploy script to update ecs task and add error logging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy to ECR
+name: Build and Deploy to ECR and ECS
 
 on:
   push:
@@ -19,16 +19,48 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-2
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Log in to Amazon ECR
-        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build and push Docker image
         run: |
-          IMAGE_TAG=latest
+          # Use commit SHA as unique image tag
+          COMMIT_SHA=$(git rev-parse --short HEAD)
+          IMAGE_TAG=$COMMIT_SHA
           ECR_REPO=arvor/research
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
           ECR_URI=$ACCOUNT_ID.dkr.ecr.us-east-2.amazonaws.com/$ECR_REPO
 
+          echo "Building image $ECR_URI:$IMAGE_TAG"
           docker build -t $ECR_URI:$IMAGE_TAG .
           docker push $ECR_URI:$IMAGE_TAG
+
+      - name: Update ECS task definition and service
+        run: |
+          # ECS variables
+          TASK_DEF_NAME=research-task
+          CLUSTER=arvor-back-office
+          SERVICE=research-task-service-6pr6cyds
+
+          # Fetch current task definition
+          aws ecs describe-task-definition --task-definition $TASK_DEF_NAME > taskdef.json
+
+          # Update container image to new image
+          jq '.taskDefinition.containerDefinitions[0].image="'$ECR_URI:$IMAGE_TAG'"' taskdef.json > new-taskdef.json
+
+          # Remove fields that are not allowed in register-task-definition
+          jq 'del(.taskDefinition.taskDefinitionArn, .taskDefinition.revision, .taskDefinition.status, .taskDefinition.requiresAttributes, .taskDefinition.compatibilities, .taskDefinition.registeredAt, .taskDefinition.registeredBy)' new-taskdef.json > final-taskdef.json
+
+          # Register new task definition
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json file://final-taskdef.json \
+            --query 'taskDefinition.taskDefinitionArn' --output text)
+
+          echo "Registered new task definition: $NEW_TASK_DEF_ARN"
+
+          # Update ECS service to use the new task definition
+          aws ecs update-service --cluster $CLUSTER --service $SERVICE --task-definition $NEW_TASK_DEF_ARN
+          echo "ECS service updated to new task definition"

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -21,4 +21,5 @@ async def run_langgraph_endpoint(user_message: UserMessage):
         graph_state = await graph.ainvoke(initial_state)
         return JSONResponse(content=graph_state)
     except Exception as e:
+        print(f"Error occurred performing research:", e)
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
### Problem

Our current deploy action sends a new image to ECR, but doesn't nothing to trigger ECS to deploy that new image.

### What's in this PR

Add a new deploy step to create a new ECS task that references the new image. This should make ECS redeploy with the new image (which is now named with the git commit).